### PR TITLE
Upgrade maven shade plugin to 3.1.0

### DIFF
--- a/babar-scalding/pom.xml
+++ b/babar-scalding/pom.xml
@@ -138,7 +138,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.1.0</version>
                 <executions>
                     <!-- Run shade goal on package phase -->
                     <execution>


### PR DESCRIPTION
Short: this upgrade the maven shade plugin for `babar-scalding` to fix a bug using asm.

Long: doing `mvn deploy`, the `shade` plugin fails on `babar-scalding`:

```
<snip>
[INFO] Including com.hadoop.gplcompression:hadoop-lzo:jar:0.4.19 in the shaded jar.
[INFO] Including org.apache.thrift:libthrift:jar:0.5.0 in the shaded jar.
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] babar 1.0-SNAPSHOT ................................. SUCCESS [  2.510 s]
[INFO] babar-agent ........................................ SUCCESS [  7.438 s]
[INFO] babar-processor .................................... SUCCESS [ 39.246 s]
[INFO] babar-scalding 1.0-SNAPSHOT ........................ FAILURE [  3.894 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 53.299 s
[INFO] Finished at: 2018-03-15T17:32:44+01:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-shade-plugin:3.0.0:shade (default) on project babar-scalding: Error creating shaded jar: Error in ASM processing class com/twitter/scalding/typed/FlattenGroup.class -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.plugins:maven-shade-plugin:3.0.0:shade (default) on project babar-scalding: Error creating shaded jar: Error in ASM processing class com/twitter/scalding/typed/FlattenGroup.class
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:213)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:154)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:146)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:956)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:290)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:194)
    at sun.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:498)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:289)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:229)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:415)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:356)
Caused by: org.apache.maven.plugin.MojoExecutionException: Error creating shaded jar: Error in ASM processing class com/twitter/scalding/typed/FlattenGroup.class
    at org.apache.maven.plugins.shade.mojo.ShadeMojo.execute (ShadeMojo.java:546)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:208)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:154)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:146)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:956)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:290)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:194)
    at sun.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:498)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:289)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:229)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:415)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:356)
Caused by: org.apache.maven.plugin.MojoExecutionException: Error in ASM processing class com/twitter/scalding/typed/FlattenGroup.class
    at org.apache.maven.plugins.shade.DefaultShader.addRemappedClass (DefaultShader.java:453)
    at org.apache.maven.plugins.shade.DefaultShader.shadeSingleJar (DefaultShader.java:220)
    at org.apache.maven.plugins.shade.DefaultShader.shadeJars (DefaultShader.java:181)
    at org.apache.maven.plugins.shade.DefaultShader.shade (DefaultShader.java:104)
    at org.apache.maven.plugins.shade.mojo.ShadeMojo.execute (ShadeMojo.java:442)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:208)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:154)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:146)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:956)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:290)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:194)
    at sun.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:498)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:289)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:229)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:415)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:356)
Caused by: java.lang.ArrayIndexOutOfBoundsException: 0
    at org.objectweb.asm.Type.getObjectType (Unknown Source)
    at org.objectweb.asm.commons.Remapper.mapType (Unknown Source)
    at org.objectweb.asm.commons.SignatureRemapper.visitClassType (Unknown Source)
    at org.objectweb.asm.signature.SignatureReader.a (Unknown Source)
    at org.objectweb.asm.signature.SignatureReader.a (Unknown Source)
    at org.objectweb.asm.signature.SignatureReader.a (Unknown Source)
    at org.objectweb.asm.signature.SignatureReader.a (Unknown Source)
    at org.objectweb.asm.signature.SignatureReader.a (Unknown Source)
    at org.objectweb.asm.signature.SignatureReader.a (Unknown Source)
    at org.objectweb.asm.signature.SignatureReader.a (Unknown Source)
    at org.objectweb.asm.signature.SignatureReader.a (Unknown Source)
    at org.objectweb.asm.signature.SignatureReader.a (Unknown Source)
    at org.objectweb.asm.signature.SignatureReader.a (Unknown Source)
    at org.objectweb.asm.signature.SignatureReader.a (Unknown Source)
    at org.objectweb.asm.signature.SignatureReader.a (Unknown Source)
    at org.objectweb.asm.signature.SignatureReader.a (Unknown Source)
    at org.objectweb.asm.signature.SignatureReader.a (Unknown Source)
    at org.objectweb.asm.signature.SignatureReader.a (Unknown Source)
    at org.objectweb.asm.signature.SignatureReader.a (Unknown Source)
    at org.objectweb.asm.signature.SignatureReader.a (Unknown Source)
    at org.objectweb.asm.signature.SignatureReader.a (Unknown Source)
    at org.objectweb.asm.signature.SignatureReader.a (Unknown Source)
    at org.objectweb.asm.signature.SignatureReader.a (Unknown Source)
    at org.objectweb.asm.signature.SignatureReader.a (Unknown Source)
    at org.objectweb.asm.signature.SignatureReader.a (Unknown Source)
    at org.objectweb.asm.signature.SignatureReader.a (Unknown Source)
    at org.objectweb.asm.signature.SignatureReader.a (Unknown Source)
    at org.objectweb.asm.signature.SignatureReader.a (Unknown Source)
    at org.objectweb.asm.signature.SignatureReader.a (Unknown Source)
    at org.objectweb.asm.signature.SignatureReader.a (Unknown Source)
    at org.objectweb.asm.signature.SignatureReader.a (Unknown Source)
    at org.objectweb.asm.signature.SignatureReader.a (Unknown Source)
    at org.objectweb.asm.signature.SignatureReader.a (Unknown Source)
    at org.objectweb.asm.signature.SignatureReader.a (Unknown Source)
    at org.objectweb.asm.signature.SignatureReader.a (Unknown Source)
    at org.objectweb.asm.signature.SignatureReader.a (Unknown Source)
    at org.objectweb.asm.signature.SignatureReader.a (Unknown Source)
    at org.objectweb.asm.signature.SignatureReader.a (Unknown Source)
    at org.objectweb.asm.signature.SignatureReader.a (Unknown Source)
    at org.objectweb.asm.signature.SignatureReader.a (Unknown Source)
    at org.objectweb.asm.signature.SignatureReader.a (Unknown Source)
    at org.objectweb.asm.signature.SignatureReader.a (Unknown Source)
    at org.objectweb.asm.signature.SignatureReader.a (Unknown Source)
    at org.objectweb.asm.signature.SignatureReader.a (Unknown Source)
    at org.objectweb.asm.signature.SignatureReader.accept (Unknown Source)
    at org.objectweb.asm.commons.Remapper.mapSignature (Unknown Source)
    at org.objectweb.asm.commons.RemappingClassAdapter.visitMethod (Unknown Source)
    at org.objectweb.asm.ClassReader.b (Unknown Source)
    at org.objectweb.asm.ClassReader.accept (Unknown Source)
    at org.objectweb.asm.ClassReader.accept (Unknown Source)
    at org.apache.maven.plugins.shade.DefaultShader.addRemappedClass (DefaultShader.java:449)
    at org.apache.maven.plugins.shade.DefaultShader.shadeSingleJar (DefaultShader.java:220)
    at org.apache.maven.plugins.shade.DefaultShader.shadeJars (DefaultShader.java:181)
    at org.apache.maven.plugins.shade.DefaultShader.shade (DefaultShader.java:104)
    at org.apache.maven.plugins.shade.mojo.ShadeMojo.execute (ShadeMojo.java:442)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:208)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:154)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:146)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:956)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:290)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:194)
    at sun.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:498)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:289)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:229)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:415)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:356)
[ERROR] 
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
[ERROR] 
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <goals> -rf :babar-scalding
```

This upgrade the plugin to 3.1.0 to fix it.
