### PR TITLE
BABAR-18 fix missing support for slashes in conf parsing

### DIFF
--- a/babar-agent/src/main/java/com/criteo/babar/agent/config/AgentConfig.java
+++ b/babar-agent/src/main/java/com/criteo/babar/agent/config/AgentConfig.java
@@ -42,7 +42,7 @@ public class AgentConfig extends Config {
             }
         }
 
-        static String kv = "([a-zA-Z0-9_\\-\\.]+)=([a-zA-Z0-9:_\\-\\.]+)";
+        static String kv = "([a-zA-Z0-9_\\-\\.]+)=([a-zA-Z0-9:_\\-\\./]+)";
         static Pattern kvPattern = Pattern.compile("^("+kv+")(.*)$");
         static Pattern profilerPattern = Pattern.compile("^([a-zA-Z0-9_\\-\\.]+)(\\[(((" + kv + ")(,)?)*)\\])?(.*)$");
 

--- a/babar-agent/src/test/java/com/criteo/babar/agent/config/ConfigParserTest.java
+++ b/babar-agent/src/test/java/com/criteo/babar/agent/config/ConfigParserTest.java
@@ -14,10 +14,10 @@ public class ConfigParserTest {
 
     @Test
     public void parseKeyValues() throws Exception {
-        AgentConfig config = AgentConfig.parse("a=b,c=d");
+        AgentConfig config = AgentConfig.parse("a=b,c=d/e");
         assertEquals(2, config.mainConfig.size());
         assertEquals("b", config.mainConfig.get("a"));
-        assertEquals("d", config.mainConfig.get("c"));
+        assertEquals("d/e", config.mainConfig.get("c"));
         assertEquals(0, config.profilersConfig.size());
     }
 


### PR DESCRIPTION
As reported in #18 , the conf parsing does not currently allow slashes in value strings. 
This commit fixes the regexp used to parse the conf key-values and updates a unit test to ensure parsing is fixed.